### PR TITLE
Downgrade the runtime to GNOME 42

### DIFF
--- a/com.hack_computer.Clippy.Extension.json
+++ b/com.hack_computer.Clippy.Extension.json
@@ -2,7 +2,7 @@
     "app-id": "com.hack_computer.Clippy.Extension",
     "runtime": "com.hack_computer.Clubhouse",
     "runtime-version": "stable",
-    "sdk": "org.gnome.Sdk//43",
+    "sdk": "org.gnome.Sdk//42",
     "appstream-compose": false,
     "separate-locales": false,
     "build-extension": true,
@@ -17,7 +17,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/endlessm/clippy.git",
-                    "commit": "fdf650145ae7a672cfbc4ed17ac725cc352e24be"
+                    "commit": "c955872bf6f9db75e6c95595c0c6a0f583348002"
                 }
             ]
         },


### PR DESCRIPTION
The Asyncio of clubhouse has compatibility issue with Python 3.10+ [1]. And, GNOME 43 runtime has Python 3.10. However, we has not had a way to fix the issue, yet. Therefore, downgrade the runtime to GNOME 42 to gain more time to fix the Asyncio compatibilty issue between clubhouse and Python 3.10+.

Follow the commit ("Downgrade the runtime to GNOME 42") of upstream clippy [2].

[1]: https://github.com/flathub/com.hack_computer.Clubhouse/issues/22#issuecomment-1352841349
[2]: https://github.com/endlessm/clippy